### PR TITLE
Bug-fix and composer.json patch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7",
         "vlucas/phpdotenv": "^5.5"
     },
     "autoload": {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -150,7 +150,7 @@ function env($key)
 	    $dotenv->load();
 	    return isset($_ENV[$key]) ? $_ENV[$key] : null;
 	}
-	catch(InvalidPathException)
+	catch(\InvalidPathException $e)
 	{
 		return null;
 	}


### PR DESCRIPTION
- Fixes the error generated by `helpers.php`:
```
syntax error, unexpected ')', expecting variable (T_VARIABLE) in /zam/src/helpers.php on line 153
```

- Increases the minimum PHP version required to PHP >= 7.

Because the package uses the null coalescence operator here:
https://github.com/SirMekus/zam/blob/c91b2ae65cc300fa3ecc60be506790d27c1aa84b/src/utility/Zam.php#L101
https://github.com/SirMekus/zam/blob/c91b2ae65cc300fa3ecc60be506790d27c1aa84b/src/utility/Zam.php#L104
https://github.com/SirMekus/zam/blob/c91b2ae65cc300fa3ecc60be506790d27c1aa84b/src/utility/Zam.php#L107
https://github.com/SirMekus/zam/blob/c91b2ae65cc300fa3ecc60be506790d27c1aa84b/src/utility/Zam.php#L110
https://github.com/SirMekus/zam/blob/c91b2ae65cc300fa3ecc60be506790d27c1aa84b/src/utility/Zam.php#L59

And support for the null coalescence operator wasn't added until PHP 7.0 ([*see here*](https://www.php.net/manual/en/migration70.new-features.php)), in its current state, the package won't work for PHP versions lower than 7. (Which shouldn't matter too much at this point I think, given that PHP 7.4, the very last version of PHP7, reached official *end of life* status in November 2022, 9 months ago now).